### PR TITLE
Prevent Safari opacity flicker on hovering brand link

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -316,6 +316,11 @@
   text-decoration: none;
   color: white;
   transition: opacity 0.2s;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
+  will-change: opacity, transform;
 
   &:hover {
     opacity: 0.9;


### PR DESCRIPTION
This PR fixes Safari rendering issues where opacity transitions flicker for brand link in Header component.

Added backface-visibility: hidden and transform: translateZ(0) (with -webkit- prefixes for older Safari versions) to force GPU layer promotion which smooths transitions without affecting layout or functionality.